### PR TITLE
feat(ci): unify release-plz tag to v{version} for workspace releases

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,15 +1,10 @@
 [workspace]
-# Update dependent path-deps when a crate is bumped
 dependencies_update = true
-# Generate changelogs from conventional commits
 changelog_update = true
-# Run `cargo semver-checks` to detect accidental breaking changes
 semver_check = true
-# Group all workspace bumps into a single release PR
 release_always = false
 
 [changelog]
-# Keep a Changelog style with conventional commit sections
 header = """# Changelog
 
 All notable changes to this project are documented in this file.
@@ -18,10 +13,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 """
 
+# metarepo-core ships alongside metarepo but does not drive its own tag or
+# GitHub Release. The workspace ships under a single unified `v{{ version }}`
+# tag created by the metarepo package below, which the release-binaries
+# workflow watches.
 [[package]]
 name = "metarepo-core"
 publish = true
+git_tag_enable = false
+git_release_enable = false
 
 [[package]]
 name = "metarepo"
 publish = true
+git_tag_name = "v{{ version }}"
+git_release_name = "v{{ version }}"


### PR DESCRIPTION
## Summary
- Configure `metarepo-core` to ship without its own tag or GitHub Release (still published to crates.io)
- Make `metarepo` the tag/release driver using `v{{ version }}` format
- Keeps `release-binaries.yml` (which triggers on `v*` tag pushes) working end-to-end with release-plz-driven releases

## Why
release-plz's default per-package tags (`metarepo-v0.13.0`, `metarepo-core-v0.13.0`) wouldn't match the `v*` filter on the binary-build workflow, and would clutter the tag list for a workspace that always ships both crates together on the same cadence.

## Test plan
- [ ] Merge PR → release-plz opens/updates the Release PR (#15)
- [ ] Merge the Release PR → release-plz creates a single `v{version}` tag, publishes both crates to crates.io, creates one GitHub Release
- [ ] Confirm `release-binaries.yml` triggers on the new `v*` tag and uploads archives to that Release