### PR TITLE
chore: release v0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -531,7 +531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -603,9 +603,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
@@ -792,9 +792,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -1275,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -1818,9 +1818,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,7 +706,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metarepo"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -722,6 +722,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "shlex",
  "tempfile",
  "thiserror",
  "tokio",
@@ -734,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "metarepo-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/meta-core/CHANGELOG.md
+++ b/meta-core/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0](https://github.com/codyaverett/metarepo/compare/metarepo-core-v0.13.0...metarepo-core-v0.14.0) - 2026-05-14
+
+### Added
+
+- *(security)* harden config and plugin
+
 ## [0.13.0](https://github.com/codyaverett/metarepo/compare/metarepo-core-v0.12.0...metarepo-core-v0.13.0) - 2026-04-23
 
 ### Added

--- a/meta-core/Cargo.toml
+++ b/meta-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metarepo-core"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Core interfaces and types for the metarepo multi-project management tool"
 authors = ["Metarepo Contributors"]

--- a/meta-core/src/lib.rs
+++ b/meta-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod interactive;
 mod plugin_base;
 mod plugin_builder;
 mod plugin_manifest;
+pub mod security;
 pub mod tui;
 
 pub use interactive::{
@@ -25,6 +26,10 @@ pub use plugin_builder::{
 pub use plugin_manifest::{
     ArgValueType, Dependency, Example, ExecutionConfig, ManifestArg, ManifestCommand, PluginConfig,
     PluginInfo, PluginManifest,
+};
+pub use security::{
+    canonicalize_creatable, ensure_within_base, is_dangerous_env_var, is_supported_git_url,
+    is_unencrypted_git_scheme, validate_path_segment, validate_project_url, DANGEROUS_ENV_VARS,
 };
 
 /// Trait that all meta plugins must implement
@@ -260,8 +265,48 @@ impl Default for MetaConfig {
 impl MetaConfig {
     pub fn load_from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let content = std::fs::read_to_string(path)?;
-        let config: MetaConfig = serde_json::from_str(&content)?;
+        let mut config: MetaConfig = serde_json::from_str(&content)?;
+        config.sanitize_after_load();
         Ok(config)
+    }
+
+    /// Apply security-driven sanitization after deserialization:
+    /// - drop project entries whose key contains path traversal / null bytes / absolute paths
+    /// - drop dangerous env vars from each ProjectMetadata
+    ///
+    /// Emits warnings to stderr for any sanitized entries so committers see them.
+    fn sanitize_after_load(&mut self) {
+        let bad_keys: Vec<String> = self
+            .projects
+            .keys()
+            .filter(|k| security::validate_path_segment("project key", k).is_err())
+            .cloned()
+            .collect();
+        for k in bad_keys {
+            eprintln!(
+                "warning: dropping project '{}' from config (invalid path segment: traversal, null, or absolute path)",
+                k
+            );
+            self.projects.remove(&k);
+        }
+
+        for (project, entry) in self.projects.iter_mut() {
+            if let ProjectEntry::Metadata(metadata) = entry {
+                let dangerous: Vec<String> = metadata
+                    .env
+                    .keys()
+                    .filter(|k| security::is_dangerous_env_var(k))
+                    .cloned()
+                    .collect();
+                for k in dangerous {
+                    eprintln!(
+                        "warning: ignoring env var '{}' for project '{}' (known to subvert subprocesses)",
+                        k, project
+                    );
+                    metadata.env.remove(&k);
+                }
+            }
+        }
     }
 
     pub fn save_to_file<P: AsRef<Path>>(&self, path: P) -> Result<()> {

--- a/meta-core/src/security.rs
+++ b/meta-core/src/security.rs
@@ -1,0 +1,229 @@
+//! Security helpers for validating untrusted inputs that flow from the `.meta`
+//! config and CLI args into filesystem paths, subprocess spawns, and child
+//! environment variables.
+//!
+//! These helpers are deliberately small and pure so that every plugin can apply
+//! the same trust boundary without re-implementing checks.
+
+use anyhow::{anyhow, Result};
+use std::path::{Component, Path, PathBuf};
+
+/// Environment variable names that can subvert child processes if attacker-controlled.
+/// We refuse to forward these from `.meta` config to subprocesses.
+pub const DANGEROUS_ENV_VARS: &[&str] = &[
+    // Dynamic linker hijacking
+    "LD_PRELOAD",
+    "LD_LIBRARY_PATH",
+    "LD_AUDIT",
+    "DYLD_INSERT_LIBRARIES",
+    "DYLD_LIBRARY_PATH",
+    "DYLD_FALLBACK_LIBRARY_PATH",
+    "DYLD_FORCE_FLAT_NAMESPACE",
+    // Shell startup hijacking
+    "BASH_ENV",
+    "ENV",
+    "PROMPT_COMMAND",
+    // Language runtime hijacking
+    "PYTHONPATH",
+    "PYTHONSTARTUP",
+    "PYTHONHOME",
+    "NODE_OPTIONS",
+    "NODE_PATH",
+    "RUBYOPT",
+    "RUBYLIB",
+    "PERL5OPT",
+    "PERL5LIB",
+    // Git command hijacking
+    "GIT_SSH_COMMAND",
+    "GIT_SSH",
+    "GIT_EXEC_PATH",
+];
+
+/// Returns true if `key` matches a known dangerous env var (case-insensitive).
+pub fn is_dangerous_env_var(key: &str) -> bool {
+    DANGEROUS_ENV_VARS
+        .iter()
+        .any(|d| d.eq_ignore_ascii_case(key))
+}
+
+/// Validate a string used as a relative path segment in config-driven path
+/// joins (project name, branch name, worktree path suffix, plugin file ref).
+/// Rejects empty values, null bytes, absolute paths, and any `..` component.
+pub fn validate_path_segment(label: &str, value: &str) -> Result<()> {
+    if value.is_empty() {
+        return Err(anyhow!("{} must not be empty", label));
+    }
+    if value.contains('\0') {
+        return Err(anyhow!("{} must not contain null bytes", label));
+    }
+    let path = Path::new(value);
+    if path.is_absolute() {
+        return Err(anyhow!(
+            "{} must be a relative path (got absolute '{}')",
+            label,
+            value
+        ));
+    }
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                return Err(anyhow!(
+                    "{} must not contain '..' segments (got '{}')",
+                    label,
+                    value
+                ));
+            }
+            Component::Prefix(_) | Component::RootDir => {
+                return Err(anyhow!(
+                    "{} must be a relative path (got '{}')",
+                    label,
+                    value
+                ));
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Verify that `joined` (which need not exist on disk yet) resolves inside
+/// `base` after canonicalization. Returns the canonical resolved path.
+///
+/// Walks up `joined` to find an existing ancestor, canonicalizes that, then
+/// re-appends the non-existing suffix — this lets us safely check paths that
+/// are about to be created.
+pub fn ensure_within_base(base: &Path, joined: &Path) -> Result<PathBuf> {
+    let canon_base = base
+        .canonicalize()
+        .map_err(|e| anyhow!("Failed to canonicalize base {:?}: {}", base, e))?;
+
+    let canon_joined = canonicalize_creatable(joined)?;
+
+    if !canon_joined.starts_with(&canon_base) {
+        return Err(anyhow!(
+            "Path {:?} escapes base directory {:?}",
+            joined,
+            base
+        ));
+    }
+    Ok(canon_joined)
+}
+
+/// Canonicalize a path that may not exist yet by canonicalizing the nearest
+/// existing ancestor and appending the remainder.
+pub fn canonicalize_creatable(path: &Path) -> Result<PathBuf> {
+    if let Ok(canon) = path.canonicalize() {
+        return Ok(canon);
+    }
+    let mut existing = path;
+    let mut suffix = PathBuf::new();
+    loop {
+        if existing.exists() {
+            break;
+        }
+        let file = existing
+            .file_name()
+            .ok_or_else(|| anyhow!("Cannot canonicalize path {:?}", path))?;
+        suffix = Path::new(file).join(&suffix);
+        existing = existing
+            .parent()
+            .ok_or_else(|| anyhow!("Cannot canonicalize path {:?}", path))?;
+        if existing.as_os_str().is_empty() {
+            return Err(anyhow!("Cannot canonicalize path {:?}", path));
+        }
+    }
+    let canon_existing = existing
+        .canonicalize()
+        .map_err(|e| anyhow!("Failed to canonicalize {:?}: {}", existing, e))?;
+    Ok(canon_existing.join(suffix))
+}
+
+/// Schemes we recognize as remote git URLs in `meta project add`.
+/// Note: `git://` is unauthenticated/unencrypted but still a real URL scheme;
+/// detecting it correctly is preferable to silently falling through to local-path
+/// handling. Callers that want to warn can check [`is_unencrypted_git_scheme`].
+pub fn is_supported_git_url(src: &str) -> bool {
+    src.starts_with("https://")
+        || src.starts_with("http://")
+        || src.starts_with("ssh://")
+        || src.starts_with("git://")
+        || src.starts_with("git@")
+}
+
+/// True for schemes that don't provide transport-level encryption/authentication.
+pub fn is_unencrypted_git_scheme(src: &str) -> bool {
+    src.starts_with("http://") || src.starts_with("git://")
+}
+
+/// Reject obviously malformed URL strings before storing them in config.
+/// Allows ssh shorthand (`git@host:repo`); just guards against control chars
+/// and empty values.
+pub fn validate_project_url(src: &str) -> Result<()> {
+    if src.is_empty() {
+        return Err(anyhow!("project URL must not be empty"));
+    }
+    if src.bytes().any(|b| b == 0 || b == b'\n' || b == b'\r') {
+        return Err(anyhow!("project URL contains invalid control characters"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_path_segment_rejects_traversal() {
+        assert!(validate_path_segment("name", "../etc").is_err());
+        assert!(validate_path_segment("name", "a/../b").is_err());
+        assert!(validate_path_segment("name", "/abs").is_err());
+        assert!(validate_path_segment("name", "").is_err());
+        assert!(validate_path_segment("name", "with\0null").is_err());
+    }
+
+    #[test]
+    fn validate_path_segment_accepts_normal_names() {
+        assert!(validate_path_segment("name", "my-project").is_ok());
+        assert!(validate_path_segment("name", "nested/subdir").is_ok());
+        assert!(validate_path_segment("branch", "feature/foo").is_ok());
+    }
+
+    #[test]
+    fn dangerous_env_detection_is_case_insensitive() {
+        assert!(is_dangerous_env_var("LD_PRELOAD"));
+        assert!(is_dangerous_env_var("ld_preload"));
+        assert!(is_dangerous_env_var("BASH_ENV"));
+        assert!(!is_dangerous_env_var("PATH"));
+        assert!(!is_dangerous_env_var("HOME"));
+    }
+
+    #[test]
+    fn url_scheme_detection_handles_git_protocol() {
+        assert!(is_supported_git_url("git://github.com/u/r.git"));
+        assert!(is_supported_git_url("https://github.com/u/r.git"));
+        assert!(is_supported_git_url("git@github.com:u/r.git"));
+        assert!(!is_supported_git_url("file:///etc/passwd"));
+        assert!(!is_supported_git_url("/local/path"));
+        assert!(is_unencrypted_git_scheme("git://x"));
+        assert!(is_unencrypted_git_scheme("http://x"));
+        assert!(!is_unencrypted_git_scheme("https://x"));
+    }
+
+    #[test]
+    fn ensure_within_base_blocks_escape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("base");
+        std::fs::create_dir(&base).unwrap();
+        let sibling = tmp.path().join("sibling");
+        std::fs::create_dir(&sibling).unwrap();
+
+        // Joining base with "../sibling" canonicalizes outside base.
+        let attempt = base.join("../sibling");
+        assert!(ensure_within_base(&base, &attempt).is_err());
+
+        // A path strictly inside base resolves cleanly.
+        let inside = base.join("sub").join("file");
+        let resolved = ensure_within_base(&base, &inside).unwrap();
+        assert!(resolved.starts_with(base.canonicalize().unwrap()));
+    }
+}

--- a/meta/CHANGELOG.md
+++ b/meta/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0](https://github.com/codyaverett/metarepo/compare/v0.13.0...v0.14.0) - 2026-05-14
+
+### Added
+
+- *(security)* harden config and plugin
+
 ## [0.13.0](https://github.com/codyaverett/metarepo/compare/v0.12.0...v0.13.0) - 2026-04-23
 
 ### Added

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metarepo"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "A powerful multi-project management tool inspired by the meta npm package - manage multiple git repositories with ease"
 authors = ["Metarepo Contributors"]
@@ -30,7 +30,7 @@ console = { workspace = true }
 ratatui = { workspace = true }
 crossterm = { workspace = true }
 tui-textarea = { workspace = true }
-metarepo-core = { version = "0.13.0", path = "../meta-core" }
+metarepo-core = { version = "0.14.0", path = "../meta-core" }
 
 # Plugin dependencies (now built-in)
 # Git plugin dependencies
@@ -43,9 +43,11 @@ toml = "0.8"
 glob = "0.3"
 walkdir = "2.4"
 regex = "1.10"
+shlex = "1.3"
 
 [dev-dependencies]
 tempfile = "3.0"
+shlex = "1.3"
 
 [features]
 default = ["all-plugins"]

--- a/meta/src/plugins/plugin_loader.rs
+++ b/meta/src/plugins/plugin_loader.rs
@@ -89,7 +89,63 @@ impl ExternalPlugin {
     pub fn version(&self) -> &str {
         &self.version
     }
+
+    /// Reject plugin paths that we wouldn't normally trust to spawn:
+    /// - paths containing `..` components (traversal)
+    /// - paths not located inside one of the allowed plugin directories
+    ///
+    /// Allowed roots:
+    ///   - `$HOME/.config/metarepo/plugins`
+    ///   - `$HOME/.cargo/bin` (where `cargo install metarepo-plugin-*` lands)
+    ///   - `<workspace>/.metarepo/plugins` (per-repo plugins, if used)
+    ///
+    /// The `METAREPO_PLUGIN_ALLOW_ANY_PATH=1` env var lets developers opt out
+    /// of the restriction for local plugin development.
+    pub fn validate_plugin_path(path: &Path) -> Result<()> {
+        if path
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            return Err(anyhow::anyhow!(
+                "Plugin path must not contain '..' segments: {:?}",
+                path
+            ));
+        }
+
+        if std::env::var_os("METAREPO_PLUGIN_ALLOW_ANY_PATH").is_some() {
+            return Ok(());
+        }
+
+        let canon = path.canonicalize().context(format!(
+            "Plugin path does not exist or is not accessible: {:?}",
+            path
+        ))?;
+
+        let mut allowed: Vec<PathBuf> = Vec::new();
+        if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
+            allowed.push(PathBuf::from(&home).join(".config/metarepo/plugins"));
+            allowed.push(PathBuf::from(&home).join(".cargo/bin"));
+        }
+        if let Ok(cwd) = std::env::current_dir() {
+            allowed.push(cwd.join(".metarepo/plugins"));
+        }
+
+        for root in &allowed {
+            if let Ok(canon_root) = root.canonicalize() {
+                if canon.starts_with(&canon_root) {
+                    return Ok(());
+                }
+            }
+        }
+
+        Err(anyhow::anyhow!(
+            "Plugin path {:?} is not in an allowed plugins directory. Allowed roots: {:?}. Set METAREPO_PLUGIN_ALLOW_ANY_PATH=1 to override.",
+            path,
+            allowed
+        ))
+    }
     pub fn load(path: &Path) -> Result<Box<dyn MetaPlugin>> {
+        Self::validate_plugin_path(path)?;
         // Start the plugin process
         let mut child = Command::new(path)
             .env("METAREPO_PLUGIN_MODE", "1")

--- a/meta/src/plugins/project/mod.rs
+++ b/meta/src/plugins/project/mod.rs
@@ -147,6 +147,13 @@ pub fn import_project_with_options(
     init_git: bool,
     bare: bool,
 ) -> Result<()> {
+    // Reject path-traversal / absolute / null-byte project names before they
+    // flow into base_path.join(...) or filesystem operations below.
+    metarepo_core::validate_path_segment("project name", project_path)?;
+    if let Some(src) = source {
+        metarepo_core::validate_project_url(src).ok(); // tolerate local paths
+    }
+
     // Find and load the .meta file
     let meta_file_path = base_path.join(".meta");
     if !meta_file_path.exists() {
@@ -166,10 +173,13 @@ pub fn import_project_with_options(
     }
 
     let local_project_path = base_path.join(project_path);
+    // Defense in depth: even though we validated project_path above, confirm
+    // the canonical join stays inside base_path.
+    metarepo_core::ensure_within_base(base_path, &local_project_path)?;
 
     // Determine what the source is and how to handle it
     let (final_repo_url, is_external) = if let Some(src) = source {
-        if !src.starts_with("http") && !src.starts_with("git@") && !src.starts_with("ssh://") {
+        if !metarepo_core::is_supported_git_url(src) {
             // This is a local path (relative or absolute)
             let external_path = if src.starts_with('/') {
                 PathBuf::from(src)
@@ -266,6 +276,13 @@ pub fn import_project_with_options(
             }
         } else {
             // Regular git URL
+            if metarepo_core::is_unencrypted_git_scheme(src) {
+                eprintln!(
+                    "  {} Source uses an unencrypted scheme ({}): traffic is unauthenticated",
+                    "⚠".yellow(),
+                    src.split("://").next().unwrap_or(src)
+                );
+            }
             (src.to_string(), false)
         }
     } else {

--- a/meta/src/plugins/run/mod.rs
+++ b/meta/src/plugins/run/mod.rs
@@ -253,13 +253,20 @@ fn execute_script_in_project(
 
     println!("     {} {}", "►".bright_black(), script_cmd.bright_white());
 
-    // Parse the command (simple split by spaces - could be improved)
-    let parts: Vec<&str> = script_cmd.split_whitespace().collect();
+    // Parse the script command with shell-style tokenization so quoted args
+    // with spaces survive intact. shlex returns None for unbalanced quotes —
+    // surface that to the caller instead of silently mis-splitting.
+    let parts = shlex::split(script_cmd).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Failed to parse script command (unbalanced quotes?): {}",
+            script_cmd
+        )
+    })?;
     if parts.is_empty() {
         return Err(anyhow::anyhow!("Empty script command"));
     }
 
-    let mut cmd = Command::new(parts[0]);
+    let mut cmd = Command::new(&parts[0]);
     if parts.len() > 1 {
         cmd.args(&parts[1..]);
     }
@@ -327,13 +334,20 @@ fn execute_script_in_project_buffered(
         )
     })?;
 
-    // Parse the command (simple split by spaces - could be improved)
-    let parts: Vec<&str> = script_cmd.split_whitespace().collect();
+    // Parse the script command with shell-style tokenization so quoted args
+    // with spaces survive intact. shlex returns None for unbalanced quotes —
+    // surface that to the caller instead of silently mis-splitting.
+    let parts = shlex::split(script_cmd).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Failed to parse script command (unbalanced quotes?): {}",
+            script_cmd
+        )
+    })?;
     if parts.is_empty() {
         return Err(anyhow::anyhow!("Empty script command"));
     }
 
-    let mut cmd = Command::new(parts[0]);
+    let mut cmd = Command::new(&parts[0]);
     if parts.len() > 1 {
         cmd.args(&parts[1..]);
     }

--- a/meta/src/plugins/worktree/mod.rs
+++ b/meta/src/plugins/worktree/mod.rs
@@ -164,6 +164,7 @@ pub fn add_worktrees(
     create_branch: bool,
     starting_point: Option<&str>,
     no_hooks: bool,
+    allow_hooks: bool,
     current_project: Option<&str>,
     config: &MetaConfig,
 ) -> Result<()> {
@@ -241,6 +242,12 @@ pub fn add_worktrees(
         // Determine worktree path based on whether this is a bare repo
         let is_bare = config.is_bare_repo(project_name);
         let worktree_dir = path_suffix.unwrap_or(branch);
+        // Reject path-traversal in branch / path_suffix before joining.
+        if let Err(e) = metarepo_core::validate_path_segment("worktree name", worktree_dir) {
+            eprintln!("  {} {}", "✗".red(), e);
+            failed.push(project_name.clone());
+            continue;
+        }
         let worktree_path = if is_bare {
             // For bare repos: <project>/<branch>/
             project_path.join(worktree_dir)
@@ -248,6 +255,12 @@ pub fn add_worktrees(
             // For normal repos: <project>/.worktrees/<branch>/
             project_path.join(".worktrees").join(worktree_dir)
         };
+        // Defense in depth: confirm the canonical path stays inside the project.
+        if let Err(e) = metarepo_core::ensure_within_base(&project_path, &worktree_path) {
+            eprintln!("  {} {}", "✗".red(), e);
+            failed.push(project_name.clone());
+            continue;
+        }
 
         // Check if worktree already exists
         if worktree_path.exists() {
@@ -341,9 +354,43 @@ pub fn add_worktrees(
             println!("  {} Complete", "✓".green());
             success_count += 1;
 
-            // Execute post-create command if configured and not skipped
+            // Execute post-create command if configured and not skipped.
+            // worktree_init is shell code from .meta — typically committed by
+            // collaborators, so we surface the command and require explicit
+            // opt-in (either --allow-hooks or an interactive confirmation).
             if !no_hooks {
                 if let Some(worktree_init) = config.get_worktree_init(project_name) {
+                    let proceed = if allow_hooks {
+                        true
+                    } else if metarepo_core::is_interactive() {
+                        println!(
+                            "  {} worktree_init hook for {}:",
+                            "🪝".yellow(),
+                            project_name.bold()
+                        );
+                        println!("     {}", worktree_init.bright_white());
+                        match metarepo_core::prompt_confirm(
+                            "  Run this hook?",
+                            false,
+                            metarepo_core::NonInteractiveMode::Defaults,
+                        ) {
+                            Ok(v) => v,
+                            Err(e) => {
+                                eprintln!("  {} Skipping hook: {}", "✗".yellow(), e);
+                                false
+                            }
+                        }
+                    } else {
+                        eprintln!(
+                            "  {} Skipping worktree_init hook (non-interactive; pass --allow-hooks to opt in)",
+                            "⚠".yellow()
+                        );
+                        false
+                    };
+
+                    if !proceed {
+                        continue;
+                    }
                     println!("  Running worktree_init...");
 
                     let mut cmd = Command::new("sh");

--- a/meta/src/plugins/worktree/plugin.rs
+++ b/meta/src/plugins/worktree/plugin.rs
@@ -94,6 +94,11 @@ impl WorktreePlugin {
                             .long("no-hooks")
                             .help("Skip running post-create worktree_init command")
                     )
+                    .arg(
+                        arg("allow-hooks")
+                            .long("allow-hooks")
+                            .help("Run worktree_init hooks without an interactive confirmation prompt (otherwise the hook command is displayed and confirmed before each run)")
+                    )
             )
             .command(
                 command("remove")
@@ -188,6 +193,7 @@ fn handle_add(matches: &ArgMatches, config: &RuntimeConfig) -> Result<()> {
     let create_branch = matches.get_flag("create-branch");
     let path_suffix = matches.get_one::<String>("path").map(|s| s.as_str());
     let no_hooks = matches.get_flag("no-hooks");
+    let allow_hooks = matches.get_flag("allow-hooks");
 
     // Prefer --from over positional commit arg
     let starting_point = from_ref.or(commit).map(|s| s.as_str());
@@ -239,6 +245,7 @@ fn handle_add(matches: &ArgMatches, config: &RuntimeConfig) -> Result<()> {
         create_branch,
         starting_point,
         no_hooks,
+        allow_hooks,
         current_project.as_deref(),
         &config.meta_config,
     )?;

--- a/meta/tests/security_tests.rs
+++ b/meta/tests/security_tests.rs
@@ -123,15 +123,11 @@ mod command_injection {
 mod path_traversal {
     use super::*;
 
-    /// MetaConfig allows project keys with path traversal sequences.
-    /// This test documents the current behavior — keys are stored as-is
-    /// in the HashMap without validation.
-    ///
-    /// SECURITY GAP: project keys like "../../etc" are accepted and later
-    /// used in base_path.join(project_name) without canonicalization.
-    /// Tracked by issue #11 (config validation).
+    /// Fixed by #11: MetaConfig::load_from_file drops project entries whose
+    /// key contains path-traversal sequences. The entry is removed before any
+    /// plugin code can join it onto base_path.
     #[test]
-    fn config_accepts_traversal_in_project_keys() {
+    fn config_rejects_traversal_in_project_keys_on_load() {
         let tmp = TempDir::new().unwrap();
         let meta_path = tmp.path().join(".meta");
 
@@ -140,14 +136,21 @@ mod path_traversal {
             "../../etc/evil".to_string(),
             ProjectEntry::Url("https://github.com/user/repo.git".to_string()),
         );
+        config.projects.insert(
+            "safe-project".to_string(),
+            ProjectEntry::Url("https://github.com/user/repo.git".to_string()),
+        );
 
         config.save_to_file(&meta_path).unwrap();
         let loaded = MetaConfig::load_from_file(&meta_path).unwrap();
 
-        // CURRENT BEHAVIOR: traversal key is accepted without validation
         assert!(
-            loaded.projects.contains_key("../../etc/evil"),
-            "Path traversal key is currently accepted (no validation)"
+            !loaded.projects.contains_key("../../etc/evil"),
+            "Traversal key must be dropped on load"
+        );
+        assert!(
+            loaded.projects.contains_key("safe-project"),
+            "Safe keys must survive sanitization"
         );
     }
 
@@ -282,30 +285,23 @@ mod config_safety {
         assert!(loaded.projects.contains_key(&long_key));
     }
 
-    /// Script commands from config are split by whitespace and passed to
-    /// Command::new(). Verify that the split_whitespace approach preserves
-    /// shell metacharacters as literal tokens.
-    ///
-    /// SECURITY GAP: While Command::new doesn't invoke a shell, the naive
-    /// split_whitespace means quoted arguments with spaces won't work
-    /// correctly, and a malicious script value like "rm -rf /" would
-    /// execute rm with args ["-rf", "/"]. The config is user-editable,
-    /// so this is a trust-boundary concern. Tracked by issue #14.
+    /// Fixed by #14: script commands are tokenized with shlex so quoted args
+    /// containing spaces are preserved as single tokens.
     #[test]
-    fn script_command_split_whitespace_behavior() {
-        // Simulate what run_script does: split a script command
-        let script_cmd = "npm run test && curl evil.com";
-        let parts: Vec<&str> = script_cmd.split_whitespace().collect();
+    fn script_command_uses_shlex_tokenization() {
+        let script_cmd = "cargo test --arg \"value with spaces\"";
+        let parts = shlex::split(script_cmd).expect("balanced quotes");
+        assert_eq!(parts.len(), 4);
+        assert_eq!(parts[0], "cargo");
+        assert_eq!(parts[3], "value with spaces");
+    }
 
-        // split_whitespace produces literal tokens — && is just a string token
-        assert_eq!(parts[0], "npm");
-        assert_eq!(parts[3], "&&");
-        assert_eq!(parts[4], "curl");
-
-        // When passed to Command::new("npm").args(&["run", "test", "&&", "curl", "evil.com"]),
-        // "&&" is a literal argument to npm, NOT a shell operator.
-        // This is safe for Command but could be confusing if the user expected
-        // shell behavior. The real danger is that parts[0] is used as the executable.
+    /// Unbalanced quotes are surfaced as an error instead of silently
+    /// producing wrong tokens.
+    #[test]
+    fn script_command_rejects_unbalanced_quotes() {
+        let script_cmd = "echo \"unbalanced";
+        assert!(shlex::split(script_cmd).is_none());
     }
 
     /// Verify that a script config value with just whitespace produces
@@ -392,30 +388,54 @@ mod config_safety {
         );
     }
 
-    /// Environment variables from config are passed to child processes
-    /// without filtering. Verify that dangerous env vars (LD_PRELOAD, etc.)
-    /// are stored in config without any blocklist.
-    ///
-    /// SECURITY GAP: No env var blocklist exists. Tracked by issue #11.
+    /// Fixed by #11: MetaConfig::load_from_file strips known dangerous env
+    /// vars from each project entry so they cannot be forwarded to child
+    /// processes via cmd.env(...).
     #[test]
-    fn env_vars_not_filtered_in_config() {
+    fn dangerous_env_vars_stripped_on_load() {
+        let tmp = TempDir::new().unwrap();
+        let meta_path = tmp.path().join(".meta");
+
         let mut env = HashMap::new();
         env.insert("LD_PRELOAD".to_string(), "/tmp/evil.so".to_string());
         env.insert("BASH_ENV".to_string(), "/tmp/evil.sh".to_string());
+        env.insert("PATH".to_string(), "/usr/local/bin".to_string());
 
-        let config_entry = ProjectMetadata {
-            url: "https://github.com/user/repo.git".to_string(),
-            aliases: vec![],
-            scripts: HashMap::new(),
-            env,
-            worktree_init: None,
-            bare: None,
+        let mut config = MetaConfig::default();
+        config.projects.insert(
+            "p".to_string(),
+            ProjectEntry::Metadata(ProjectMetadata {
+                url: "https://github.com/user/repo.git".to_string(),
+                aliases: vec![],
+                scripts: HashMap::new(),
+                env,
+                worktree_init: None,
+                bare: None,
+            }),
+        );
+        config.save_to_file(&meta_path).unwrap();
+
+        let loaded = MetaConfig::load_from_file(&meta_path).unwrap();
+        let entry = loaded.projects.get("p").unwrap();
+        let env = match entry {
+            ProjectEntry::Metadata(m) => &m.env,
+            _ => panic!("expected metadata entry"),
         };
+        assert!(
+            !env.contains_key("LD_PRELOAD"),
+            "LD_PRELOAD must be stripped"
+        );
+        assert!(!env.contains_key("BASH_ENV"), "BASH_ENV must be stripped");
+        assert!(env.contains_key("PATH"), "innocuous vars survive");
+    }
 
-        // CURRENT BEHAVIOR: dangerous env vars are stored and would be
-        // passed to child processes via cmd.env(key, value)
-        assert!(config_entry.env.contains_key("LD_PRELOAD"));
-        assert!(config_entry.env.contains_key("BASH_ENV"));
+    #[test]
+    fn dangerous_env_helper_recognizes_known_keys() {
+        use metarepo_core::is_dangerous_env_var;
+        assert!(is_dangerous_env_var("LD_PRELOAD"));
+        assert!(is_dangerous_env_var("DYLD_INSERT_LIBRARIES"));
+        assert!(is_dangerous_env_var("NODE_OPTIONS"));
+        assert!(!is_dangerous_env_var("PATH"));
     }
 }
 
@@ -454,18 +474,19 @@ mod url_validation {
         }
     }
 
-    /// SECURITY GAP: git:// protocol (unauthenticated, unencrypted) is not
-    /// explicitly handled — it falls through to the "local path" branch.
-    /// Tracked by issue #13.
+    /// Fixed by #13: the centralized helper recognizes git:// as a URL scheme
+    /// (and flags it as unencrypted so callers can warn).
     #[test]
-    fn git_protocol_not_detected_as_url() {
-        let input = "git://github.com/user/repo.git";
-        let is_url =
-            input.starts_with("http") || input.starts_with("git@") || input.starts_with("ssh://");
-        assert!(
-            !is_url,
-            "git:// protocol is not detected as a URL — falls through to local path handling"
-        );
+    fn git_protocol_is_detected_as_url() {
+        use metarepo_core::{is_supported_git_url, is_unencrypted_git_scheme};
+        assert!(is_supported_git_url("git://github.com/user/repo.git"));
+        assert!(is_unencrypted_git_scheme("git://github.com/user/repo.git"));
+        assert!(!is_unencrypted_git_scheme(
+            "https://github.com/user/repo.git"
+        ));
+        // file:// is still NOT treated as a remote URL — it falls through to
+        // local-path handling, which now goes through validate_path_segment.
+        assert!(!is_supported_git_url("file:///etc/passwd"));
     }
 
     /// Verify that MetaConfig stores arbitrary URL strings without validation.
@@ -510,48 +531,36 @@ mod plugin_safety {
         );
     }
 
-    /// ExternalPlugin::load accepts absolute paths outside the plugins
-    /// directory. There is no path validation.
-    ///
-    /// SECURITY GAP: Any path can be passed to ExternalPlugin::load.
-    /// No check ensures the path is within the expected plugins directory.
-    /// Tracked by issue #12.
+    /// Fixed by #12: ExternalPlugin::load rejects paths outside the allowed
+    /// plugin directories. /bin/echo is not under a metarepo plugin root, so
+    /// validation fails before spawn.
     #[test]
-    fn plugin_load_accepts_absolute_paths() {
-        // /bin/echo exists and is executable, but it doesn't speak the
-        // plugin protocol, so it will fail at the protocol level —
-        // the important thing is that path validation doesn't reject it.
+    fn plugin_load_rejects_path_outside_allowed_roots() {
         let result = metarepo::plugins::ExternalPlugin::load(Path::new("/bin/echo"));
-
-        // It will fail because /bin/echo doesn't respond with the plugin protocol,
-        // NOT because the path is rejected. This documents the gap:
-        // there is no path validation before spawning.
-        let err_msg = match result {
-            Ok(_) => panic!("/bin/echo should not load successfully as a plugin"),
-            Err(e) => e.to_string(),
+        let err = match result {
+            Ok(_) => panic!("/bin/echo must be rejected by path validation"),
+            Err(e) => e,
         };
-
-        // The error should be about protocol, not "path not allowed"
+        let msg = err.to_string();
         assert!(
-            !err_msg.contains("not allowed") && !err_msg.contains("invalid path"),
-            "Error should be protocol-related, not path-related — no path validation exists. Got: {}",
-            err_msg
+            msg.contains("not in an allowed plugins directory") || msg.contains("does not exist"),
+            "Expected path-policy rejection, got: {}",
+            msg
         );
     }
 
-    /// Verify that plugin paths with traversal sequences are not rejected.
-    ///
-    /// SECURITY GAP: No traversal check on plugin paths. Tracked by issue #12.
+    /// Fixed by #12: plugin paths containing `..` are rejected outright.
     #[test]
-    fn plugin_load_does_not_reject_traversal_paths() {
-        // Attempt to load a plugin with ../ in the path
+    fn plugin_load_rejects_traversal_paths() {
         let result = metarepo::plugins::ExternalPlugin::load(Path::new("../../../usr/bin/true"));
-
-        // Will fail because /usr/bin/true doesn't speak plugin protocol,
-        // but the path itself is not rejected
+        let err = match result {
+            Ok(_) => panic!("traversal path must be rejected"),
+            Err(e) => e,
+        };
         assert!(
-            result.is_err(),
-            "Should fail, but at protocol or spawn level, not path validation"
+            err.to_string().contains("'..'"),
+            "Expected traversal rejection, got: {}",
+            err
         );
     }
 }


### PR DESCRIPTION



## 🤖 New release

* `metarepo-core`: 0.13.0 -> 0.14.0
* `metarepo`: 0.13.0 -> 0.14.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `metarepo-core`

<blockquote>

## [0.14.0](https://github.com/codyaverett/metarepo/compare/metarepo-core-v0.13.0...metarepo-core-v0.14.0) - 2026-05-14

### Added

- *(security)* harden config and plugin
</blockquote>

## `metarepo`

<blockquote>

## [0.14.0](https://github.com/codyaverett/metarepo/compare/v0.13.0...v0.14.0) - 2026-05-14

### Added

- *(security)* harden config and plugin
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).