### PR TITLE
chore: release v0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,14 +111,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -694,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.28"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "libc",
@@ -733,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru"
@@ -757,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "metarepo"
@@ -782,7 +782,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
- "shlex",
+ "shlex 1.3.0",
  "tempfile",
  "thiserror",
  "tokio",
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -862,18 +862,18 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.2+3.5.2"
+version = "300.6.0+3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d270b79e2926f5150189d475bc7e9d2c69f9c4697b185fa917d5a32b792d21b4"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -1128,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1194,6 +1194,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,9 +1238,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1519,9 +1525,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,7 +763,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metarepo"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "metarepo-core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "metarepo-plugin-sdk"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "metarepo-core",

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ meta git update
 | **config** | `meta config <edit\|show\|get\|set\|validate>` | Configuration management with interactive TUI |
 | **exec** | `meta exec [flags] <command>` | Execute commands across repositories |
 | **run** | `meta run [flags] <script>` | Run scripts defined in `.meta` |
-| **worktree** | `meta worktree <add\|remove\|list\|prune>` | Git worktree management across workspace |
+| **worktree** | `meta worktree <add\|remove\|list\|prune\|clean\|repair>` | Git worktree management across workspace (`clean` removes merged worktrees) |
 | **rules** | `meta -x rules <check\|init\|list\|...>` | Project structure enforcement (experimental) |
 | **plugin** | `meta -x plugin <add\|install\|remove\|list\|update>` | External plugin management (experimental) |
 | **mcp** | `meta -x mcp <add\|list\|connect\|serve\|...>` | Model Context Protocol integration (experimental) |

--- a/docs/WORKTREE.md
+++ b/docs/WORKTREE.md
@@ -130,6 +130,81 @@ Post-create commands have access to project-specific environment variables defin
 - **Environment**: Inherits project-specific environment variables from `.meta`
 - **Failure handling**: Hook failures are reported but don't prevent worktree creation
 
+## Cleaning Up Worktrees
+
+Two commands help you keep a workspace tidy. They are different operations:
+
+| Command | What it does | Destructive? |
+|---------|--------------|--------------|
+| `meta worktree prune` | Removes git's *administrative references* to worktrees whose directories no longer exist | No — never deletes a worktree that still has files |
+| `meta worktree clean` | Removes *worktrees* whose branches are already merged (or have no changes) into the base branch | Yes — but heavily gated and confirmed |
+
+### `meta worktree prune`
+
+Wraps `git worktree prune` per project and reports exactly what it removed (or
+"nothing to prune") plus a summary:
+
+```bash
+meta worktree prune            # remove stale references
+meta worktree prune --dry-run  # show what would be removed
+meta worktree prune --global   # across all projects, ignoring directory context
+```
+
+Prune only removes references to worktree directories that are already gone. It
+**never** deletes a worktree that still has files, so it cannot lose uncommitted
+work.
+
+### `meta worktree clean`
+
+Removes worktrees for branches that have already landed — for example old
+feature branches — and deletes their local branches. Alias: `meta worktree tidy`.
+
+```bash
+meta worktree clean                 # preview candidates, then confirm
+meta worktree clean --dry-run       # show candidates only, remove nothing
+meta worktree clean --yes           # skip the confirmation prompt
+meta worktree clean --keep-branches # remove worktrees but keep their branches
+meta worktree clean --global        # across every project
+```
+
+**Eligibility.** A worktree is a candidate when its branch is either:
+- fully merged into the project's base branch (an ordinary merge), or
+- has no diff against the base branch (catches squash- and rebase-merged
+  branches, and branches with no changes of their own — "merged without
+  changes").
+
+The base branch is detected per project via `origin/HEAD`, falling back to
+`main`/`master`/`develop`.
+
+**Safety gates (always skipped, and shown in a "Skipped" section so you can see
+why):**
+- worktrees with uncommitted or untracked changes
+- locked worktrees
+- detached-HEAD worktrees
+- each project's primary worktree
+
+Nothing is removed until you confirm. The candidate list (project, branch,
+reason, and last-commit age) is printed first, then a single `[y/N]` prompt.
+`--dry-run` stops after the preview; `--yes` skips the prompt for automation.
+
+**Branches.** Each removed worktree's local branch is deleted with `git branch
+-d`, which refuses to delete a branch that isn't fully merged. If it refuses
+(e.g. a squash-merged branch that has no diff but isn't an ancestor of base),
+the branch is kept and reported so you can delete it manually if intended.
+`--keep-branches` skips branch deletion entirely.
+
+### Directory-aware scope (clean)
+
+`meta worktree clean` chooses which projects to act on from your current
+directory:
+
+- **inside a project** → only that project
+- **inside a subdirectory** that contains projects → the projects beneath it
+- **at the workspace root** → every project
+
+Use `--global` to force all projects, or `--project <name>` / `--projects
+a,b,c` to target specific ones regardless of the current directory.
+
 ## Bare Repository Support
 
 ### Quick Start: Adding Bare Repositories

--- a/meta-core/CHANGELOG.md
+++ b/meta-core/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.0](https://github.com/codyaverett/metarepo/compare/metarepo-core-v0.23.0...metarepo-core-v0.24.0) - 2026-06-01
+
+### Added
+
+- *(worktree)* add clean command and clearer prune output (v0.24.0)
+
 ## [0.17.0](https://github.com/codyaverett/metarepo/compare/metarepo-core-v0.13.0...metarepo-core-v0.17.0) - 2026-05-14
 
 ### Added

--- a/meta-core/Cargo.toml
+++ b/meta-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metarepo-core"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Core interfaces and types for the metarepo multi-project management tool"
 authors = ["Metarepo Contributors"]

--- a/meta/CHANGELOG.md
+++ b/meta/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.0](https://github.com/codyaverett/metarepo/compare/v0.23.0...v0.24.0) - 2026-06-01
+
+### Added
+
+- *(worktree)* add clean command and clearer prune output (v0.24.0)
+
 ## [0.17.0](https://github.com/codyaverett/metarepo/compare/v0.13.0...v0.17.0) - 2026-05-14
 
 ### Added

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metarepo"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "A powerful multi-project management tool inspired by the meta npm package - manage multiple git repositories with ease"
 authors = ["Metarepo Contributors"]
@@ -31,7 +31,7 @@ console = { workspace = true }
 ratatui = { workspace = true }
 crossterm = { workspace = true }
 tui-textarea = { workspace = true }
-metarepo-core = { version = "0.23.0", path = "../meta-core" }
+metarepo-core = { version = "0.24.0", path = "../meta-core" }
 
 # Plugin dependencies (now built-in)
 # Git plugin dependencies

--- a/meta/src/plugins/worktree/mod.rs
+++ b/meta/src/plugins/worktree/mod.rs
@@ -15,6 +15,7 @@ pub struct WorktreeInfo {
     pub path: PathBuf,
     pub is_bare: bool,
     pub is_detached: bool,
+    pub is_locked: bool,
     pub head: Option<String>,
 }
 
@@ -126,6 +127,7 @@ pub fn list_worktrees(repo_path: &Path) -> Result<Vec<WorktreeInfo>> {
                 path: PathBuf::from(path),
                 is_bare: false,
                 is_detached: false,
+                is_locked: false,
                 head: None,
             });
         } else if line.starts_with("HEAD ") {
@@ -144,6 +146,11 @@ pub fn list_worktrees(repo_path: &Path) -> Result<Vec<WorktreeInfo>> {
             if let Some(ref mut wt) = current_worktree {
                 wt.is_detached = true;
             }
+        } else if line == "locked" || line.starts_with("locked ") {
+            // Porcelain emits a bare `locked` line, or `locked <reason>`.
+            if let Some(ref mut wt) = current_worktree {
+                wt.is_locked = true;
+            }
         }
     }
 
@@ -152,6 +159,99 @@ pub fn list_worktrees(repo_path: &Path) -> Result<Vec<WorktreeInfo>> {
     }
 
     Ok(worktrees)
+}
+
+/// Strip the `refs/heads/` prefix from a branch ref, if present.
+fn short_branch_name(branch_ref: &str) -> &str {
+    branch_ref.strip_prefix("refs/heads/").unwrap_or(branch_ref)
+}
+
+/// True if `refname` resolves in the given repo.
+fn git_ref_exists(project_path: &Path, refname: &str) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(project_path)
+        .arg("rev-parse")
+        .arg("--verify")
+        .arg("--quiet")
+        .arg(refname)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Resolve the ref that worktree branches should be compared against, given the
+/// project's base branch name. Prefers the local base branch; otherwise falls
+/// back to the remote-tracking ref, then the bare name.
+fn resolve_base_ref(project_path: &Path, base_name: &str) -> String {
+    if git_ref_exists(project_path, base_name) {
+        return base_name.to_string();
+    }
+    let remote = format!("origin/{}", base_name);
+    if git_ref_exists(project_path, &remote) {
+        return remote;
+    }
+    base_name.to_string()
+}
+
+/// True if `branch_ref` is fully contained in `base_ref` (an ordinary merge):
+/// the branch tip is an ancestor of base.
+fn branch_is_merged(project_path: &Path, branch_ref: &str, base_ref: &str) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(project_path)
+        .arg("merge-base")
+        .arg("--is-ancestor")
+        .arg(branch_ref)
+        .arg(base_ref)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// True if `branch_ref` introduces no changes relative to `base_ref`. Uses a
+/// three-dot diff so it catches squash- and rebase-merged branches (whose tips
+/// are not ancestors of base) as well as branches with no commits of their own.
+fn branch_has_no_diff(project_path: &Path, branch_ref: &str, base_ref: &str) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(project_path)
+        .arg("diff")
+        .arg("--quiet")
+        .arg(format!("{}...{}", base_ref, branch_ref))
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// True if the worktree at `wt_path` has uncommitted or untracked changes.
+fn worktree_is_dirty(wt_path: &Path) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(wt_path)
+        .arg("status")
+        .arg("--porcelain")
+        .output()
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false)
+}
+
+/// Relative date of the last commit on `branch_ref` (e.g. "3 weeks ago").
+fn last_commit_relative(project_path: &Path, branch_ref: &str) -> Option<String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(project_path)
+        .arg("log")
+        .arg("-1")
+        .arg("--format=%cr")
+        .arg(branch_ref)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!s.is_empty()).then_some(s)
 }
 
 /// Add a worktree for selected projects
@@ -743,6 +843,9 @@ pub fn prune_worktrees(
         println!("\nPruning stale worktrees\n");
     }
 
+    let mut total_pruned = 0usize;
+    let mut repos_with_stale = 0usize;
+
     for project_name in project_iter {
         let project_path = base_path.join(project_name);
 
@@ -761,28 +864,346 @@ pub fn prune_worktrees(
         if dry_run {
             cmd.arg("--dry-run");
         }
-
         cmd.arg("--verbose");
 
-        // Stream git output in real-time
-        cmd.stdout(Stdio::inherit()).stderr(Stdio::inherit());
-
-        let _status = cmd
-            .status()
+        // Capture rather than inherit: `git worktree prune --verbose` only emits
+        // a "Removing ..." line per stale entry and is silent when there is
+        // nothing to do. Parsing it lets us say what was (or would be) pruned
+        // and report "nothing to prune" instead of leaving the user guessing.
+        let output = cmd
+            .output()
             .context(format!("Failed to prune worktrees for {}", project_name))?;
+
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let pruned_lines: Vec<&str> = combined
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| l.starts_with("Removing "))
+            .collect();
+
+        if pruned_lines.is_empty() {
+            println!("  {} nothing to prune", "·".bright_black());
+        } else {
+            repos_with_stale += 1;
+            for line in &pruned_lines {
+                total_pruned += 1;
+                let verb = if dry_run { "would remove" } else { "removed" };
+                // Strip git's leading "Removing " so we can prepend our own verb.
+                let detail = line.strip_prefix("Removing ").unwrap_or(line);
+                println!("  {} {} {}", "✓".green(), verb, detail);
+            }
+        }
     }
 
-    if dry_run {
-        println!("\n{}", "Check complete".dimmed());
-        println!(
-            "{}",
-            "Run without --dry-run to remove stale worktrees".dimmed()
-        );
+    let entry_word = if total_pruned == 1 {
+        "entry"
     } else {
-        println!("\n{}", "Prune complete".green());
+        "entries"
+    };
+    let repo_word = if repos_with_stale == 1 {
+        "repo"
+    } else {
+        "repos"
+    };
+    if dry_run {
+        println!(
+            "\n{}",
+            format!(
+                "Would prune {} stale {} across {} {}",
+                total_pruned, entry_word, repos_with_stale, repo_word
+            )
+            .dimmed()
+        );
+        if total_pruned > 0 {
+            println!("{}", "Run without --dry-run to remove them".dimmed());
+        }
+    } else {
+        println!(
+            "\n{} {} stale {} removed across {} {}",
+            "Prune complete:".green(),
+            total_pruned,
+            entry_word,
+            repos_with_stale,
+            repo_word
+        );
     }
+    println!(
+        "{}",
+        "Prune only removes references to worktree directories that no longer exist; \
+         it never deletes a worktree that still has files."
+            .dimmed()
+    );
 
     Ok(())
+}
+
+/// Options controlling [`clean_worktrees`].
+#[derive(Debug, Clone, Copy)]
+pub struct CleanOptions {
+    pub dry_run: bool,
+    pub assume_yes: bool,
+    pub keep_branches: bool,
+}
+
+/// A worktree eligible for cleanup, with the reason it qualified.
+struct CleanCandidate {
+    project: String,
+    project_path: PathBuf,
+    wt_path: PathBuf,
+    branch_ref: String,
+    reason: String,
+    age: Option<String>,
+}
+
+/// A worktree that resembled a cleanup target but was skipped, with the reason.
+struct CleanSkip {
+    project: String,
+    label: String,
+    reason: String,
+}
+
+/// Remove worktrees whose branches are already merged into (or contribute no
+/// changes relative to) their project's base branch. Destructive, but gated:
+/// dirty, locked, detached, and primary worktrees are always skipped, and a
+/// confirmation is required before anything is removed (unless `assume_yes`).
+pub fn clean_worktrees(
+    base_path: &Path,
+    scope_projects: &[String],
+    opts: CleanOptions,
+    non_interactive: metarepo_core::NonInteractiveMode,
+) -> Result<()> {
+    let meta_file_path = base_path.join(".meta");
+    if !meta_file_path.exists() {
+        return Err(anyhow::anyhow!(
+            "No .meta file found. Run 'meta init' first."
+        ));
+    }
+    let config = MetaConfig::load_from_file(&meta_file_path)?;
+
+    let mut candidates: Vec<CleanCandidate> = Vec::new();
+    let mut skipped: Vec<CleanSkip> = Vec::new();
+
+    for project_name in scope_projects {
+        if !config.projects.contains_key(project_name) {
+            continue;
+        }
+        let project_path = base_path.join(project_name);
+        if !project_path.exists() || !project_path.join(".git").exists() {
+            continue;
+        }
+        let Ok(worktrees) = list_worktrees(&project_path) else {
+            continue;
+        };
+
+        let base_name = crate::plugins::shared::detect_default_branch(&project_path)
+            .unwrap_or_else(|_| "main".to_string());
+        let base_ref = resolve_base_ref(&project_path, &base_name);
+
+        for wt in worktrees {
+            // Never touch the primary working tree or a bare entry.
+            if wt.is_bare || wt.path == project_path {
+                continue;
+            }
+
+            let label = if !wt.branch.is_empty() {
+                short_branch_name(&wt.branch).to_string()
+            } else {
+                wt.path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_else(|| "unknown".to_string())
+            };
+
+            if wt.is_locked {
+                skipped.push(CleanSkip {
+                    project: project_name.clone(),
+                    label,
+                    reason: "locked".to_string(),
+                });
+                continue;
+            }
+            if wt.is_detached || wt.branch.is_empty() {
+                skipped.push(CleanSkip {
+                    project: project_name.clone(),
+                    label,
+                    reason: "detached HEAD".to_string(),
+                });
+                continue;
+            }
+            // Don't evaluate a worktree that has the base branch checked out.
+            if short_branch_name(&wt.branch) == base_name {
+                continue;
+            }
+            if worktree_is_dirty(&wt.path) {
+                skipped.push(CleanSkip {
+                    project: project_name.clone(),
+                    label,
+                    reason: "uncommitted changes".to_string(),
+                });
+                continue;
+            }
+
+            let merged = branch_is_merged(&project_path, &wt.branch, &base_ref);
+            let no_diff = !merged && branch_has_no_diff(&project_path, &wt.branch, &base_ref);
+            if merged || no_diff {
+                let reason = if merged {
+                    format!("merged into {}", base_name)
+                } else {
+                    format!("no changes vs {}", base_name)
+                };
+                candidates.push(CleanCandidate {
+                    age: last_commit_relative(&project_path, &wt.branch),
+                    project: project_name.clone(),
+                    project_path: project_path.clone(),
+                    wt_path: wt.path.clone(),
+                    branch_ref: wt.branch.clone(),
+                    reason,
+                });
+            } else {
+                skipped.push(CleanSkip {
+                    project: project_name.clone(),
+                    label,
+                    reason: "not merged".to_string(),
+                });
+            }
+        }
+    }
+
+    println!("\n{}\n", "Cleaning up merged worktrees".bold());
+
+    if candidates.is_empty() {
+        println!("{}", "Nothing to clean up".dimmed());
+        print_clean_skips(&skipped);
+        println!();
+        return Ok(());
+    }
+
+    println!("{}", "Worktrees eligible for cleanup:".bold());
+    for c in &candidates {
+        let rel = c
+            .wt_path
+            .strip_prefix(base_path)
+            .unwrap_or(&c.wt_path)
+            .display();
+        let location = match &c.age {
+            Some(age) => format!("{} ({})", rel, age),
+            None => format!("{}", rel),
+        };
+        println!(
+            "  {} {}  {}  {}",
+            c.project.bright_blue(),
+            short_branch_name(&c.branch_ref).white(),
+            c.reason.green(),
+            location.dimmed()
+        );
+    }
+    print_clean_skips(&skipped);
+
+    if opts.dry_run {
+        println!("\n{}", "Dry run — nothing removed".dimmed());
+        println!(
+            "{}",
+            "Run without --dry-run to remove these worktrees".dimmed()
+        );
+        return Ok(());
+    }
+
+    if !opts.assume_yes {
+        let proceed = metarepo_core::prompt_confirm(
+            &format!(
+                "Remove {} worktree{}?",
+                candidates.len(),
+                if candidates.len() == 1 { "" } else { "s" }
+            ),
+            false,
+            non_interactive,
+        )?;
+        if !proceed {
+            println!("{}", "Aborted — nothing removed".dimmed());
+            return Ok(());
+        }
+    }
+
+    println!();
+    let mut removed = 0usize;
+    let mut branches_deleted = 0usize;
+    let mut failed = 0usize;
+
+    for c in &candidates {
+        let short = short_branch_name(&c.branch_ref);
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(&c.project_path)
+            .arg("worktree")
+            .arg("remove")
+            .arg(&c.wt_path)
+            .status();
+
+        match status {
+            Ok(s) if s.success() => {
+                removed += 1;
+                println!("  {} {} ({})", "✓".green(), short, c.project.bright_blue());
+
+                if !opts.keep_branches {
+                    let del = Command::new("git")
+                        .arg("-C")
+                        .arg(&c.project_path)
+                        .arg("branch")
+                        .arg("-d")
+                        .arg(short)
+                        .output();
+                    match del {
+                        Ok(o) if o.status.success() => branches_deleted += 1,
+                        _ => println!(
+                            "    {} kept branch {} (delete manually if intended)",
+                            "·".bright_black(),
+                            short
+                        ),
+                    }
+                }
+            }
+            _ => {
+                failed += 1;
+                eprintln!("  {} {} ({})", "✗".red(), short, c.project.bright_blue());
+            }
+        }
+    }
+
+    println!(
+        "\nSummary: {} removed, {} branch{} deleted, {} skipped{}",
+        removed.to_string().green(),
+        branches_deleted.to_string().green(),
+        if branches_deleted == 1 { "" } else { "es" },
+        skipped.len().to_string().bright_black(),
+        if failed > 0 {
+            format!(", {} failed", failed.to_string().red())
+        } else {
+            String::new()
+        }
+    );
+
+    Ok(())
+}
+
+/// Print the dimmed "Skipped" section listing worktrees that were not eligible.
+fn print_clean_skips(skipped: &[CleanSkip]) {
+    if skipped.is_empty() {
+        return;
+    }
+    println!("\n{}", "Skipped (not eligible):".dimmed());
+    for s in skipped {
+        println!(
+            "  {} {} ({}) — {}",
+            "·".bright_black(),
+            s.label,
+            s.project.bright_blue(),
+            s.reason.dimmed()
+        );
+    }
 }
 
 /// Repair worktree administrative paths after worktrees have been moved on

--- a/meta/src/plugins/worktree/plugin.rs
+++ b/meta/src/plugins/worktree/plugin.rs
@@ -1,5 +1,6 @@
 use super::{
-    add_worktrees, list_all_worktrees, prune_worktrees, remove_worktrees, repair_worktrees,
+    add_worktrees, clean_worktrees, list_all_worktrees, prune_worktrees, remove_worktrees,
+    repair_worktrees, CleanOptions,
 };
 use anyhow::Result;
 use clap::ArgMatches;
@@ -8,6 +9,7 @@ use metarepo_core::{
     arg, command, is_interactive, plugin, prompt_multiselect, prompt_text, BasePlugin, MetaPlugin,
     NonInteractiveMode, RuntimeConfig,
 };
+use std::path::Path;
 
 /// WorktreePlugin using the simplified plugin architecture
 pub struct WorktreePlugin;
@@ -218,11 +220,71 @@ impl WorktreePlugin {
                             .help("Repair worktrees across all projects, ignoring the current project directory context")
                     )
             )
+            .command(
+                command("clean")
+                    .about("Remove worktrees whose branches are already merged")
+                    .aliases(vec!["tidy".to_string()])
+                    .long_about("Remove worktrees whose branches are already merged into (or contribute\n\
+                                 no changes relative to) their project's base branch — for example old\n\
+                                 feature branches that have already landed.\n\n\
+                                 Safe by design: worktrees with uncommitted or untracked changes, locked\n\
+                                 worktrees, detached HEADs, and each project's primary worktree are always\n\
+                                 skipped, and you are shown the full list and asked to confirm before\n\
+                                 anything is removed. Each removed worktree's local branch is deleted with\n\
+                                 'git branch -d' (which refuses unmerged branches) unless --keep-branches.\n\n\
+                                 Scope follows the current directory: inside a project it cleans that\n\
+                                 project; inside a subdirectory it cleans the projects beneath it; at the\n\
+                                 workspace root it cleans every project. Use --global to force all.\n\n\
+                                 Examples:\n\
+                                   meta worktree clean                  # Preview, then confirm\n\
+                                   meta worktree clean --dry-run        # Show candidates only\n\
+                                   meta worktree clean --yes            # Skip the confirmation prompt\n\
+                                   meta worktree clean --keep-branches  # Remove worktrees, keep branches\n\
+                                   meta worktree clean --global         # Across every project")
+                    .with_help_formatting()
+                    .arg(
+                        arg("dry-run")
+                            .long("dry-run")
+                            .short('n')
+                            .help("Show what would be removed without removing anything")
+                    )
+                    .arg(
+                        arg("yes")
+                            .long("yes")
+                            .short('y')
+                            .help("Skip the confirmation prompt and remove eligible worktrees")
+                    )
+                    .arg(
+                        arg("keep-branches")
+                            .long("keep-branches")
+                            .help("Remove the worktrees but do not delete their local branches")
+                    )
+                    .arg(
+                        arg("project")
+                            .long("project")
+                            .short('p')
+                            .help("Clean a single project (overrides directory context)")
+                            .takes_value(true)
+                    )
+                    .arg(
+                        arg("projects")
+                            .long("projects")
+                            .help("Clean a comma-separated list of projects (overrides directory context)")
+                            .takes_value(true)
+                    )
+                    .arg(
+                        arg("global")
+                            .long("global")
+                            .short('g')
+                            .help("Clean worktrees across all projects, ignoring the current directory context")
+                    )
+            )
             .handler("add", handle_add)
             .handler("remove", handle_remove)
             .handler("list", handle_list)
             .handler("prune", handle_prune)
             .handler("repair", handle_repair)
+            .handler("clean", handle_clean)
             .build()
     }
 }
@@ -453,6 +515,89 @@ fn handle_repair(matches: &ArgMatches, config: &RuntimeConfig) -> Result<()> {
     Ok(())
 }
 
+/// Handler for the clean command.
+fn handle_clean(matches: &ArgMatches, config: &RuntimeConfig) -> Result<()> {
+    let base_path = config.meta_root().unwrap_or(config.working_dir.clone());
+    let opts = CleanOptions {
+        dry_run: matches.get_flag("dry-run"),
+        assume_yes: matches.get_flag("yes"),
+        keep_branches: matches.get_flag("keep-branches"),
+    };
+    let non_interactive = config
+        .non_interactive
+        .unwrap_or(NonInteractiveMode::Defaults);
+
+    // Scope resolution: explicit --project/--projects win, then --global, then
+    // the directory-context-aware default.
+    let scope: Vec<String> = if matches.get_flag("global") {
+        config.meta_config.projects.keys().cloned().collect()
+    } else if let Some(project) = matches.get_one::<String>("project") {
+        vec![config
+            .resolve_project(project)
+            .unwrap_or_else(|| project.clone())]
+    } else if let Some(list) = matches.get_one::<String>("projects") {
+        list.split(',')
+            .map(|p| {
+                let trimmed = p.trim();
+                config
+                    .resolve_project(trimmed)
+                    .unwrap_or_else(|| trimmed.to_string())
+            })
+            .collect()
+    } else {
+        let meta_root = config
+            .meta_root()
+            .unwrap_or_else(|| config.working_dir.clone());
+        let keys: Vec<String> = config.meta_config.projects.keys().cloned().collect();
+        projects_in_scope(
+            &meta_root,
+            &config.working_dir,
+            &keys,
+            config.current_project(),
+        )
+    };
+
+    if scope.is_empty() {
+        println!("\n{}", "No projects in scope for cleanup".dimmed());
+        return Ok(());
+    }
+
+    clean_worktrees(&base_path, &scope, opts, non_interactive)?;
+    Ok(())
+}
+
+/// Resolve which project keys are in scope for a directory-context-aware
+/// command, given the workspace root, the current working directory, all
+/// project keys, and the project the cwd is inside (if any):
+///
+/// - inside a project (`current_project` is `Some`) → just that project
+/// - at the workspace root, or outside it entirely → all projects
+/// - in a subdirectory of the root → the projects nested beneath it
+fn projects_in_scope(
+    meta_root: &Path,
+    working_dir: &Path,
+    project_keys: &[String],
+    current_project: Option<String>,
+) -> Vec<String> {
+    if let Some(project) = current_project {
+        return vec![project];
+    }
+    let Ok(rel) = working_dir.strip_prefix(meta_root) else {
+        // cwd is outside the workspace root — operate on everything.
+        return project_keys.to_vec();
+    };
+    if rel.as_os_str().is_empty() {
+        // At the workspace root.
+        return project_keys.to_vec();
+    }
+    // In a subdirectory: keep only projects whose key path is nested under it.
+    project_keys
+        .iter()
+        .filter(|key| Path::new(key).starts_with(rel))
+        .cloned()
+        .collect()
+}
+
 // Traditional implementation for backward compatibility
 impl MetaPlugin for WorktreePlugin {
     fn name(&self) -> &str {
@@ -489,5 +634,66 @@ impl BasePlugin for WorktreePlugin {
 impl Default for WorktreePlugin {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::projects_in_scope;
+    use std::path::Path;
+
+    fn keys(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn scope_inside_a_project_targets_only_that_project() {
+        // current_project resolves to the project the cwd is inside.
+        let scope = projects_in_scope(
+            Path::new("/ws"),
+            Path::new("/ws/app/src"),
+            &keys(&["app", "api", "plugins/a"]),
+            Some("app".to_string()),
+        );
+        assert_eq!(scope, vec!["app".to_string()]);
+    }
+
+    #[test]
+    fn scope_at_workspace_root_targets_all_projects() {
+        let all = keys(&["app", "api", "plugins/a"]);
+        let scope = projects_in_scope(Path::new("/ws"), Path::new("/ws"), &all, None);
+        assert_eq!(scope, all);
+    }
+
+    #[test]
+    fn scope_in_a_subdirectory_targets_projects_beneath_it() {
+        let scope = projects_in_scope(
+            Path::new("/ws"),
+            Path::new("/ws/plugins"),
+            &keys(&["app", "plugins/a", "plugins/b", "tools/x"]),
+            None,
+        );
+        assert_eq!(
+            scope,
+            vec!["plugins/a".to_string(), "plugins/b".to_string()]
+        );
+    }
+
+    #[test]
+    fn scope_in_an_empty_subdirectory_is_empty() {
+        let scope = projects_in_scope(
+            Path::new("/ws"),
+            Path::new("/ws/docs"),
+            &keys(&["app", "plugins/a"]),
+            None,
+        );
+        assert!(scope.is_empty());
+    }
+
+    #[test]
+    fn scope_outside_the_workspace_targets_all_projects() {
+        let all = keys(&["app", "api"]);
+        let scope = projects_in_scope(Path::new("/ws"), Path::new("/elsewhere"), &all, None);
+        assert_eq!(scope, all);
     }
 }

--- a/meta/tests/worktree_clean_tests.rs
+++ b/meta/tests/worktree_clean_tests.rs
@@ -1,0 +1,212 @@
+// End-to-end tests for `meta worktree clean` (clean_worktrees).
+//
+// These build real git repositories under an isolated workspace and call
+// clean_worktrees directly with assume_yes, so no interactive prompt is needed.
+// They verify the safety contract: merged worktrees are removed (and their
+// branches deleted), while unmerged and dirty worktrees are left untouched.
+
+use metarepo::plugins::worktree::{clean_worktrees, CleanOptions};
+use metarepo_core::{MetaConfig, NonInteractiveMode, ProjectEntry};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+/// A workspace containing a single git project "alpha" on branch `main`.
+struct Workspace {
+    _tmp: TempDir,
+    root: PathBuf,
+    project: PathBuf,
+}
+
+fn setup() -> Workspace {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let project = root.join("alpha");
+    std::fs::create_dir(&project).unwrap();
+
+    let mut config = MetaConfig::default();
+    config.projects.insert(
+        "alpha".to_string(),
+        ProjectEntry::Url("https://example.com/alpha.git".to_string()),
+    );
+    config.save_to_file(root.join(".meta")).unwrap();
+
+    run_git(&project, &["init", "-q", "-b", "main"]);
+    std::fs::write(project.join("README.md"), "hello").unwrap();
+    run_git(&project, &["add", "."]);
+    run_git(&project, &["commit", "-q", "-m", "init"]);
+
+    Workspace {
+        _tmp: tmp,
+        root,
+        project,
+    }
+}
+
+/// Add a worktree on a new branch, then add a commit on that branch inside the
+/// worktree. Returns the worktree path.
+fn add_worktree_with_commit(project: &Path, branch: &str) -> PathBuf {
+    let path = project.join(".worktrees").join(branch);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    run_git(
+        project,
+        &[
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            branch,
+            path.to_str().unwrap(),
+        ],
+    );
+    std::fs::write(path.join("work.txt"), branch).unwrap();
+    run_git(&path, &["add", "."]);
+    run_git(&path, &["commit", "-q", "-m", "work"]);
+    path
+}
+
+fn opts(dry_run: bool) -> CleanOptions {
+    CleanOptions {
+        dry_run,
+        assume_yes: true,
+        keep_branches: false,
+    }
+}
+
+#[test]
+fn merged_worktree_is_removed_and_branch_deleted() {
+    if !git_available() {
+        eprintln!("skipping: git not available");
+        return;
+    }
+    let ws = setup();
+    let wt = add_worktree_with_commit(&ws.project, "feature");
+    // Fast-forward main to include feature, making it fully merged.
+    run_git(&ws.project, &["merge", "-q", "feature"]);
+
+    clean_worktrees(
+        &ws.root,
+        &["alpha".to_string()],
+        opts(false),
+        NonInteractiveMode::Defaults,
+    )
+    .expect("clean must succeed");
+
+    assert!(!wt.exists(), "merged worktree should have been removed");
+    assert!(
+        !branch_exists(&ws.project, "feature"),
+        "merged branch should have been deleted"
+    );
+}
+
+#[test]
+fn unmerged_worktree_is_kept() {
+    if !git_available() {
+        eprintln!("skipping: git not available");
+        return;
+    }
+    let ws = setup();
+    let wt = add_worktree_with_commit(&ws.project, "wip");
+    // Do NOT merge: `wip` has a unique commit, so it must be preserved.
+
+    clean_worktrees(
+        &ws.root,
+        &["alpha".to_string()],
+        opts(false),
+        NonInteractiveMode::Defaults,
+    )
+    .expect("clean must succeed");
+
+    assert!(wt.exists(), "unmerged worktree must be kept");
+    assert!(
+        branch_exists(&ws.project, "wip"),
+        "unmerged branch must be kept"
+    );
+}
+
+#[test]
+fn dirty_merged_worktree_is_skipped() {
+    if !git_available() {
+        eprintln!("skipping: git not available");
+        return;
+    }
+    let ws = setup();
+    let wt = add_worktree_with_commit(&ws.project, "feature");
+    run_git(&ws.project, &["merge", "-q", "feature"]);
+    // Introduce an uncommitted (untracked) file — the worktree is now dirty.
+    std::fs::write(wt.join("scratch.txt"), "uncommitted").unwrap();
+
+    clean_worktrees(
+        &ws.root,
+        &["alpha".to_string()],
+        opts(false),
+        NonInteractiveMode::Defaults,
+    )
+    .expect("clean must succeed");
+
+    assert!(
+        wt.exists(),
+        "a merged-but-dirty worktree must be skipped, not removed"
+    );
+}
+
+#[test]
+fn dry_run_removes_nothing() {
+    if !git_available() {
+        eprintln!("skipping: git not available");
+        return;
+    }
+    let ws = setup();
+    let wt = add_worktree_with_commit(&ws.project, "feature");
+    run_git(&ws.project, &["merge", "-q", "feature"]);
+
+    clean_worktrees(
+        &ws.root,
+        &["alpha".to_string()],
+        opts(true), // dry-run
+        NonInteractiveMode::Defaults,
+    )
+    .expect("dry-run clean must succeed");
+
+    assert!(wt.exists(), "dry-run must not remove worktrees");
+    assert!(
+        branch_exists(&ws.project, "feature"),
+        "dry-run must not delete branches"
+    );
+}
+
+fn git_available() -> bool {
+    Command::new("git")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn branch_exists(repo: &Path, name: &str) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args([
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("refs/heads/{}", name),
+        ])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run_git(dir: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["-c", "commit.gpgsign=false"])
+        .args(["-c", "user.name=Test"])
+        .args(["-c", "user.email=test@example.com"])
+        .args(args)
+        .status()
+        .unwrap_or_else(|e| panic!("git {:?} failed to spawn: {}", args, e));
+    assert!(status.success(), "git {:?} failed", args);
+}

--- a/metarepo-plugin-sdk/CHANGELOG.md
+++ b/metarepo-plugin-sdk/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.24.0](https://github.com/codyaverett/metarepo/compare/metarepo-plugin-sdk-v0.23.0...metarepo-plugin-sdk-v0.24.0) - 2026-06-01
+
+### Added
+
+- *(worktree)* add clean command and clearer prune output (v0.24.0)

--- a/metarepo-plugin-sdk/Cargo.toml
+++ b/metarepo-plugin-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metarepo-plugin-sdk"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "SDK for authoring external plugins for the metarepo CLI: implement a trait, call serve(), and the v1 stdio protocol is handled for you"
 authors = ["Metarepo Contributors"]
@@ -13,7 +13,7 @@ categories = ["development-tools", "command-line-utilities"]
 readme = "README.md"
 
 [dependencies]
-metarepo-core = { version = "0.23.0", path = "../meta-core" }
+metarepo-core = { version = "0.24.0", path = "../meta-core" }
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 


### PR DESCRIPTION



## 🤖 New release

* `metarepo-core`: 0.23.0 -> 0.24.0
* `metarepo`: 0.23.0 -> 0.24.0
* `metarepo-plugin-sdk`: 0.23.0 -> 0.24.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `metarepo-core`

<blockquote>

## [0.24.0](https://github.com/codyaverett/metarepo/compare/metarepo-core-v0.23.0...metarepo-core-v0.24.0) - 2026-06-01

### Added

- *(worktree)* add clean command and clearer prune output (v0.24.0)
</blockquote>

## `metarepo`

<blockquote>

## [0.24.0](https://github.com/codyaverett/metarepo/compare/v0.23.0...v0.24.0) - 2026-06-01

### Added

- *(worktree)* add clean command and clearer prune output (v0.24.0)
</blockquote>

## `metarepo-plugin-sdk`

<blockquote>

## [0.24.0](https://github.com/codyaverett/metarepo/compare/metarepo-plugin-sdk-v0.23.0...metarepo-plugin-sdk-v0.24.0) - 2026-06-01

### Added

- *(worktree)* add clean command and clearer prune output (v0.24.0)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).