### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,7 +763,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metarepo"
-version = "0.51.2"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -111,14 +111,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -694,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.28"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "libc",
@@ -733,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru"
@@ -757,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "metarepo"
@@ -782,7 +782,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
- "shlex",
+ "shlex 1.3.0",
  "tempfile",
  "thiserror",
  "tokio",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "metarepo-plugin-sdk"
-version = "0.51.0"
+version = "0.51.1"
 dependencies = [
  "anyhow",
  "metarepo-core",
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -862,18 +862,18 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.2+3.5.2"
+version = "300.6.1+3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d270b79e2926f5150189d475bc7e9d2c69f9c4697b185fa917d5a32b792d21b4"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -1010,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1033,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustix"
@@ -1128,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1194,6 +1194,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,9 +1238,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1519,9 +1525,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
@@ -1898,9 +1904,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",

--- a/docs/SKILL_TOOLS.md
+++ b/docs/SKILL_TOOLS.md
@@ -38,6 +38,23 @@ The `skill` plugin now covers the full lifecycle of working with skills:
 | Vetting skills | `audit` |
 | Importing skills | `steal` (local path or git URL), `add` (skills.sh) |
 
+### Bundled skill update safety
+
+`install` and `update` record a sha256 fingerprint of the files they write in
+`.claude/skills/meta-tool/.skill-lock.json`. `meta skill update` only rewrites
+the skill when the installed files still match that fingerprint (a pristine
+copy of an older bundle). It refuses — leaving the files untouched and
+explaining why — when:
+
+- the installed files were locally modified,
+- the installed version is newer than the bundled one (downgrade), or
+- no fingerprint was recorded (legacy or hand-rolled install).
+
+Pass `--force` / `-f` to overwrite anyway. `update` no longer installs the
+skill when absent; `meta skill install` (or `meta init --with-skill`) is the
+opt-in entry point. Pristine legacy installs gain a fingerprint on their next
+successful `update`/`install`.
+
 ## Subcommands
 
 ### scan

--- a/meta-core/CHANGELOG.md
+++ b/meta-core/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.51.1](https://github.com/codyaverett/metarepo/compare/metarepo-core-v0.51.0...metarepo-core-v0.51.1) - 2026-06-11
+
+### Fixed
+
+- *(plugins)* resolve Windows executable extensions for plugin binaries (v0.51.1)
+
 ## [0.17.0](https://github.com/codyaverett/metarepo/compare/metarepo-core-v0.13.0...metarepo-core-v0.17.0) - 2026-05-14
 
 ### Added

--- a/meta/CHANGELOG.md
+++ b/meta/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.52.0](https://github.com/codyaverett/metarepo/compare/v0.51.0...v0.52.0) - 2026-06-11
+
+### Added
+
+- *(skill)* refuse to clobber modified or newer installed skills on update (v0.52.0)
+
+### Fixed
+
+- *(ci)* replace mem forget with TempDir keep in module enable tests (v0.51.2)
+- *(plugins)* resolve Windows executable extensions for plugin binaries (v0.51.1)
+
 ## [0.17.0](https://github.com/codyaverett/metarepo/compare/v0.13.0...v0.17.0) - 2026-05-14
 
 ### Added

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metarepo"
-version = "0.51.2"
+version = "0.52.0"
 edition = "2021"
 description = "A powerful multi-project management tool inspired by the meta npm package - manage multiple git repositories with ease"
 authors = ["Metarepo Contributors"]

--- a/meta/src/plugins/skill/mod.rs
+++ b/meta/src/plugins/skill/mod.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -72,7 +73,49 @@ pub fn is_installed(workspace: &Path) -> bool {
     skill_root(workspace).join("SKILL.md").exists()
 }
 
-/// Write the bundled skill files into `workspace`, overwriting whatever is there.
+/// Lock file recording the fingerprint of the files we last wrote, so `update`
+/// can tell a pristine install from a locally modified one.
+const LOCK_FILE: &str = ".skill-lock.json";
+
+/// Hex sha256 over the skill's content files. Length-prefixed so file
+/// boundaries cannot be confused.
+fn fingerprint(skill_md: &str, changelog: &str) -> String {
+    let mut hasher = Sha256::new();
+    for part in [skill_md, changelog] {
+        hasher.update(part.len().to_le_bytes());
+        hasher.update(part.as_bytes());
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+/// Fingerprint recorded at the last install/update, if any. Legacy installs
+/// (written before lock files existed) have none.
+fn recorded_fingerprint(workspace: &Path) -> Option<String> {
+    let raw = fs::read_to_string(skill_root(workspace).join(LOCK_FILE)).ok()?;
+    let parsed: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    Some(parsed.get("sha256")?.as_str()?.to_string())
+}
+
+/// Fingerprint of the files currently on disk (missing files hash as empty).
+fn installed_fingerprint(workspace: &Path) -> Option<String> {
+    let root = skill_root(workspace);
+    let skill_md = fs::read_to_string(root.join("SKILL.md")).ok()?;
+    let changelog =
+        fs::read_to_string(root.join("references").join("CHANGELOG_NOTES.md")).unwrap_or_default();
+    Some(fingerprint(&skill_md, &changelog))
+}
+
+fn write_lock(root: &Path) -> Result<()> {
+    let lock = serde_json::json!({
+        "version": bundled_version(),
+        "sha256": fingerprint(SKILL_MD, SKILL_CHANGELOG),
+    });
+    fs::write(root.join(LOCK_FILE), serde_json::to_string_pretty(&lock)?)?;
+    Ok(())
+}
+
+/// Write the bundled skill files into `workspace`, overwriting whatever is
+/// there, and record their fingerprint in the lock file.
 pub fn write_skill(workspace: &Path) -> Result<()> {
     let root = skill_root(workspace);
     fs::create_dir_all(root.join("references"))?;
@@ -81,6 +124,7 @@ pub fn write_skill(workspace: &Path) -> Result<()> {
         root.join("references").join("CHANGELOG_NOTES.md"),
         SKILL_CHANGELOG,
     )?;
+    write_lock(&root)?;
     Ok(())
 }
 
@@ -93,6 +137,24 @@ pub enum SkillAction {
         to: Option<String>,
     },
     AlreadyCurrent,
+    /// `update` ran but no skill is installed; install is the opt-in step.
+    NotInstalled,
+    /// `update` declined to overwrite the installed copy (see the reason).
+    Refused(UpdateRefusal),
+}
+
+/// Why `update` refused to rewrite an installed skill without `--force`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum UpdateRefusal {
+    /// The installed files differ from the fingerprint recorded at install
+    /// time: the user (or something else) edited them.
+    LocallyModified,
+    /// The installed version is newer than the bundled one; updating would be
+    /// a downgrade.
+    InstalledNewer { installed: String, bundled: String },
+    /// No fingerprint was recorded (legacy or hand-rolled install), so a
+    /// pristine copy cannot be told apart from an edited one.
+    UnknownProvenance,
 }
 
 /// Install the skill. With `force`, always rewrite. Otherwise install only when
@@ -113,24 +175,64 @@ pub fn install(workspace: &Path, force: bool) -> Result<SkillAction> {
     Ok(SkillAction::AlreadyCurrent)
 }
 
-/// Refresh an installed skill when the bundled version differs. Installs if
-/// absent. Compares version strings; a missing version on either side is treated
-/// as "unknown" and triggers a rewrite to be safe.
-pub fn update(workspace: &Path) -> Result<SkillAction> {
+/// Refresh an installed skill to the bundled copy, but only when it is safe:
+/// the installed files must match the fingerprint recorded when they were
+/// written, and the installed version must not be newer than the bundled one.
+/// Anything else is refused (overridable with `force`). Does not install when
+/// absent — `install`/`init` are the opt-in entry points.
+pub fn update(workspace: &Path, force: bool) -> Result<SkillAction> {
     if !is_installed(workspace) {
-        write_skill(workspace)?;
-        return Ok(SkillAction::Installed);
+        return Ok(SkillAction::NotInstalled);
     }
     let installed = installed_version(workspace);
     let bundled = bundled_version();
-    if installed.is_some() && installed == bundled {
+    if force {
+        write_skill(workspace)?;
+        return Ok(SkillAction::Updated {
+            from: installed,
+            to: bundled,
+        });
+    }
+
+    // Content identical to the bundle: nothing to do. Backfill the lock so
+    // legacy installs (written before lock files existed) gain a fingerprint.
+    let on_disk = installed_fingerprint(workspace);
+    if on_disk.as_deref() == Some(fingerprint(SKILL_MD, SKILL_CHANGELOG).as_str()) {
+        if recorded_fingerprint(workspace).is_none() {
+            write_lock(&skill_root(workspace))?;
+        }
         return Ok(SkillAction::AlreadyCurrent);
     }
-    write_skill(workspace)?;
-    Ok(SkillAction::Updated {
-        from: installed,
-        to: bundled,
-    })
+
+    // Downgrade guard: never silently replace a newer installed skill.
+    if let (Some(inst), Some(bund)) = (
+        installed
+            .as_deref()
+            .and_then(|v| v.parse::<semver::Version>().ok()),
+        bundled
+            .as_deref()
+            .and_then(|v| v.parse::<semver::Version>().ok()),
+    ) {
+        if inst > bund {
+            return Ok(SkillAction::Refused(UpdateRefusal::InstalledNewer {
+                installed: inst.to_string(),
+                bundled: bund.to_string(),
+            }));
+        }
+    }
+
+    match recorded_fingerprint(workspace) {
+        Some(recorded) if on_disk.as_deref() == Some(recorded.as_str()) => {
+            // Pristine copy of an older bundle: safe to refresh.
+            write_skill(workspace)?;
+            Ok(SkillAction::Updated {
+                from: installed,
+                to: bundled,
+            })
+        }
+        Some(_) => Ok(SkillAction::Refused(UpdateRefusal::LocallyModified)),
+        None => Ok(SkillAction::Refused(UpdateRefusal::UnknownProvenance)),
+    }
 }
 
 /// Remove an installed skill directory. Returns true if something was removed.
@@ -190,18 +292,29 @@ mod tests {
         }
     }
 
-    #[test]
-    fn update_refreshes_when_version_differs() {
-        let tmp = tempdir().unwrap();
-        // Install a stale version by hand.
-        let root = tmp.path().join(".claude/skills/meta-tool");
+    /// Write an old-version skill by hand, optionally with a lock that matches
+    /// its content (i.e. a pristine install of an older bundle).
+    fn write_stale_skill(workspace: &Path, with_lock: bool) {
+        let root = workspace.join(".claude/skills/meta-tool");
         fs::create_dir_all(root.join("references")).unwrap();
-        fs::write(
-            root.join("SKILL.md"),
-            "---\nname: meta-cli\nversion: 0.0.1\n---\nold\n",
-        )
-        .unwrap();
-        match update(tmp.path()).unwrap() {
+        let skill_md = "---\nname: meta-cli\nversion: 0.0.1\n---\nold\n";
+        let changelog = "old notes\n";
+        fs::write(root.join("SKILL.md"), skill_md).unwrap();
+        fs::write(root.join("references/CHANGELOG_NOTES.md"), changelog).unwrap();
+        if with_lock {
+            let lock = serde_json::json!({
+                "version": "0.0.1",
+                "sha256": fingerprint(skill_md, changelog),
+            });
+            fs::write(root.join(LOCK_FILE), lock.to_string()).unwrap();
+        }
+    }
+
+    #[test]
+    fn update_refreshes_pristine_older_install() {
+        let tmp = tempdir().unwrap();
+        write_stale_skill(tmp.path(), true);
+        match update(tmp.path(), false).unwrap() {
             SkillAction::Updated { from, to } => {
                 assert_eq!(from, Some("0.0.1".to_string()));
                 assert_eq!(to, bundled_version());
@@ -212,10 +325,84 @@ mod tests {
     }
 
     #[test]
-    fn update_is_noop_when_current() {
+    fn update_refuses_without_recorded_fingerprint() {
+        let tmp = tempdir().unwrap();
+        write_stale_skill(tmp.path(), false);
+        assert_eq!(
+            update(tmp.path(), false).unwrap(),
+            SkillAction::Refused(UpdateRefusal::UnknownProvenance)
+        );
+        // Untouched.
+        assert_eq!(installed_version(tmp.path()), Some("0.0.1".to_string()));
+    }
+
+    #[test]
+    fn update_refuses_locally_modified_install() {
         let tmp = tempdir().unwrap();
         install(tmp.path(), false).unwrap();
-        assert_eq!(update(tmp.path()).unwrap(), SkillAction::AlreadyCurrent);
+        let md = tmp.path().join(".claude/skills/meta-tool/SKILL.md");
+        let mut contents = fs::read_to_string(&md).unwrap();
+        contents.push_str("\nlocal tweak\n");
+        fs::write(&md, &contents).unwrap();
+        assert_eq!(
+            update(tmp.path(), false).unwrap(),
+            SkillAction::Refused(UpdateRefusal::LocallyModified)
+        );
+        // The edit survives.
+        assert_eq!(fs::read_to_string(&md).unwrap(), contents);
+    }
+
+    #[test]
+    fn update_force_overwrites_modified_install() {
+        let tmp = tempdir().unwrap();
+        install(tmp.path(), false).unwrap();
+        let md = tmp.path().join(".claude/skills/meta-tool/SKILL.md");
+        fs::write(&md, "---\nname: meta-cli\nversion: 0.0.1\n---\nedited\n").unwrap();
+        match update(tmp.path(), true).unwrap() {
+            SkillAction::Updated { to, .. } => assert_eq!(to, bundled_version()),
+            other => panic!("expected Updated, got {other:?}"),
+        }
+        assert_eq!(installed_version(tmp.path()), bundled_version());
+    }
+
+    #[test]
+    fn update_refuses_downgrade_of_newer_install() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join(".claude/skills/meta-tool");
+        fs::create_dir_all(root.join("references")).unwrap();
+        let skill_md = "---\nname: meta-cli\nversion: 99.0.0\n---\nfuture\n";
+        fs::write(root.join("SKILL.md"), skill_md).unwrap();
+        fs::write(root.join("references/CHANGELOG_NOTES.md"), "notes\n").unwrap();
+        match update(tmp.path(), false).unwrap() {
+            SkillAction::Refused(UpdateRefusal::InstalledNewer { installed, .. }) => {
+                assert_eq!(installed, "99.0.0");
+            }
+            other => panic!("expected InstalledNewer refusal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn update_does_not_install_when_absent() {
+        let tmp = tempdir().unwrap();
+        assert_eq!(
+            update(tmp.path(), false).unwrap(),
+            SkillAction::NotInstalled
+        );
+        assert!(!is_installed(tmp.path()));
+    }
+
+    #[test]
+    fn update_is_noop_when_current_and_backfills_lock() {
+        let tmp = tempdir().unwrap();
+        install(tmp.path(), false).unwrap();
+        // Simulate a legacy install: drop the lock, content still pristine.
+        let lock = tmp.path().join(".claude/skills/meta-tool").join(LOCK_FILE);
+        fs::remove_file(&lock).unwrap();
+        assert_eq!(
+            update(tmp.path(), false).unwrap(),
+            SkillAction::AlreadyCurrent
+        );
+        assert!(lock.exists());
     }
 
     #[test]

--- a/meta/src/plugins/skill/plugin.rs
+++ b/meta/src/plugins/skill/plugin.rs
@@ -1,6 +1,6 @@
 use super::{
     adapt, audit, bundled_version, install, installed_version, is_installed, locations, registry,
-    remove, scan, search, steal, update, SkillAction,
+    remove, scan, search, steal, update, SkillAction, UpdateRefusal,
 };
 use anyhow::Result;
 use clap::{Arg, ArgAction, ArgMatches, Command};
@@ -137,6 +137,29 @@ fn print_action(action: &SkillAction) {
             "  {} Claude Code skill already up to date",
             "·".bright_black()
         ),
+        SkillAction::NotInstalled => println!(
+            "  {} Skill not installed; nothing to update. Run 'meta skill install' to opt in.",
+            "·".bright_black()
+        ),
+        SkillAction::Refused(reason) => {
+            match reason {
+                UpdateRefusal::LocallyModified => println!(
+                    "  {} Skill has local modifications; refusing to overwrite them.",
+                    "⚠".yellow()
+                ),
+                UpdateRefusal::InstalledNewer { installed, bundled } => println!(
+                    "  {} Installed skill ({installed}) is newer than the bundled one ({bundled}); refusing to downgrade.",
+                    "⚠".yellow()
+                ),
+                UpdateRefusal::UnknownProvenance => println!(
+                    "  {} Installed skill has no recorded fingerprint, so local edits cannot be ruled out; refusing to overwrite.",
+                    "⚠".yellow()
+                ),
+            }
+            println!(
+                "    Back up or diff .claude/skills/meta-tool/ first, then re-run with 'meta skill update --force' to overwrite."
+            );
+        }
     }
 }
 
@@ -232,8 +255,8 @@ impl MetaPlugin for SkillPlugin {
                 print_action(&action);
                 Ok(())
             }
-            Some(("update", _)) => {
-                let action = update(&config.working_dir)?;
+            Some(("update", m)) => {
+                let action = update(&config.working_dir, m.get_flag("force"))?;
                 print_action(&action);
                 Ok(())
             }
@@ -414,14 +437,25 @@ fn skill_command() -> Command {
                 .after_long_help(metarepo_core::format_help_description(
                     "Refresh the installed meta-tool skill to the bundled version.\n\
                      \n\
-                     Compares the version installed under .claude/skills/meta-tool/\n\
-                     against the version shipped with this binary and rewrites the\n\
-                     skill when the bundled one is newer. When the installed copy is\n\
-                     already current this reports that and makes no changes.\n\
+                     Rewrites .claude/skills/meta-tool/ only when it is safe: the\n\
+                     installed files must match the fingerprint recorded when they\n\
+                     were written (no local edits) and must not be newer than the\n\
+                     bundled version. Locally modified, newer, or unrecognized\n\
+                     installs are left untouched with an explanation; pass\n\
+                     --force / -f to overwrite anyway. Does not install the skill\n\
+                     when absent (use meta skill install).\n\
                      \n\
                      Examples:\n  \
-                       meta skill update   Update when a newer version is bundled",
-                )),
+                       meta skill update      Update when safe\n  \
+                       meta skill update -f   Overwrite local edits with the bundle",
+                ))
+                .arg(
+                    Arg::new("force")
+                        .long("force")
+                        .short('f')
+                        .action(ArgAction::SetTrue)
+                        .help("Overwrite even if the installed skill was edited or is newer"),
+                ),
         )
         .subcommand(
             Command::new("status")

--- a/metarepo-plugin-sdk/CHANGELOG.md
+++ b/metarepo-plugin-sdk/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.51.1](https://github.com/codyaverett/metarepo/compare/metarepo-plugin-sdk-v0.51.0...metarepo-plugin-sdk-v0.51.1) - 2026-06-11
+
+### Other
+
+- updated the following local packages: metarepo-core

--- a/metarepo-plugin-sdk/Cargo.toml
+++ b/metarepo-plugin-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metarepo-plugin-sdk"
-version = "0.51.0"
+version = "0.51.1"
 edition = "2021"
 description = "SDK for authoring external plugins for the metarepo CLI: implement a trait, call serve(), and the v1 stdio protocol is handled for you"
 authors = ["Metarepo Contributors"]
@@ -13,7 +13,7 @@ categories = ["development-tools", "command-line-utilities"]
 readme = "README.md"
 
 [dependencies]
-metarepo-core = { version = "0.51.0", path = "../meta-core" }
+metarepo-core = { version = "0.51.1", path = "../meta-core" }
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 


### PR DESCRIPTION



## 🤖 New release

* `metarepo-core`: 0.51.0 -> 0.51.1
* `metarepo`: 0.51.0 -> 0.52.0
* `metarepo-plugin-sdk`: 0.51.0 -> 0.51.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `metarepo-core`

<blockquote>

## [0.51.1](https://github.com/codyaverett/metarepo/compare/metarepo-core-v0.51.0...metarepo-core-v0.51.1) - 2026-06-11

### Fixed

- *(plugins)* resolve Windows executable extensions for plugin binaries (v0.51.1)
</blockquote>

## `metarepo`

<blockquote>

## [0.52.0](https://github.com/codyaverett/metarepo/compare/v0.51.0...v0.52.0) - 2026-06-11

### Added

- *(skill)* refuse to clobber modified or newer installed skills on update (v0.52.0)

### Fixed

- *(ci)* replace mem forget with TempDir keep in module enable tests (v0.51.2)
- *(plugins)* resolve Windows executable extensions for plugin binaries (v0.51.1)
</blockquote>

## `metarepo-plugin-sdk`

<blockquote>

## [0.51.1](https://github.com/codyaverett/metarepo/compare/metarepo-plugin-sdk-v0.51.0...metarepo-plugin-sdk-v0.51.1) - 2026-06-11

### Other

- updated the following local packages: metarepo-core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).