### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -111,14 +111,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -351,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -710,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.28"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "libc",
@@ -749,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru"
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "metarepo"
@@ -798,7 +798,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
- "shlex",
+ "shlex 1.3.0",
  "tempfile",
  "thiserror",
  "tokio",
@@ -839,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -878,18 +878,18 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.2+3.5.2"
+version = "300.6.1+3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d270b79e2926f5150189d475bc7e9d2c69f9c4697b185fa917d5a32b792d21b4"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -1210,6 +1210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,15 +1248,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1533,9 +1539,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
@@ -1903,9 +1909,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",

--- a/meta-core/CHANGELOG.md
+++ b/meta-core/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.53.2](https://github.com/codyaverett/metarepo/compare/metarepo-core-v0.52.0...metarepo-core-v0.53.2) - 2026-06-12
+
+### Added
+
+- *(skill)* steal and add skills from a specific git branch, tag, or commit (v0.53.0)
+
+### Other
+
+- *(deps)* bump toml from 0.8.23 to 1.1.2+spec-1.1.0
+- *(security)* add supply-chain threat model document (v0.53.2)
+- *(backlog)* add 2026-06-12 backlog grooming record (v0.53.1)
+
 ## [0.17.0](https://github.com/codyaverett/metarepo/compare/metarepo-core-v0.13.0...metarepo-core-v0.17.0) - 2026-05-14
 
 ### Added

--- a/meta/CHANGELOG.md
+++ b/meta/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.53.2](https://github.com/codyaverett/metarepo/compare/v0.52.0...v0.53.2) - 2026-06-12
+
+### Added
+
+- *(skill)* steal and add skills from a specific git branch, tag, or commit (v0.53.0)
+
+### Other
+
+- *(deps)* bump git2 from 0.18.3 to 0.21.0
+- *(deps)* bump sha2 from 0.10.9 to 0.11.0
+- *(deps)* bump toml from 0.8.23 to 1.1.2+spec-1.1.0
+- *(deps)* bump colored from 2.2.0 to 3.1.1
+- *(security)* add supply-chain threat model document (v0.53.2)
+- *(backlog)* add 2026-06-12 backlog grooming record (v0.53.1)
+
 ## [0.17.0](https://github.com/codyaverett/metarepo/compare/v0.13.0...v0.17.0) - 2026-05-14
 
 ### Added

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -31,7 +31,7 @@ console = { workspace = true }
 ratatui = { workspace = true }
 crossterm = { workspace = true }
 tui-textarea = { workspace = true }
-metarepo-core = { version = "0.53.1", path = "../meta-core" }
+metarepo-core = { version = "0.53.2", path = "../meta-core" }
 
 # Plugin dependencies (now built-in)
 # Git plugin dependencies

--- a/metarepo-plugin-sdk/CHANGELOG.md
+++ b/metarepo-plugin-sdk/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.53.0](https://github.com/codyaverett/metarepo/compare/metarepo-plugin-sdk-v0.52.0...metarepo-plugin-sdk-v0.53.0) - 2026-06-12
+
+### Added
+
+- *(skill)* steal and add skills from a specific git branch, tag, or commit (v0.53.0)

--- a/metarepo-plugin-sdk/Cargo.toml
+++ b/metarepo-plugin-sdk/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools", "command-line-utilities"]
 readme = "README.md"
 
 [dependencies]
-metarepo-core = { version = "0.53.0", path = "../meta-core" }
+metarepo-core = { version = "0.53.2", path = "../meta-core" }
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 


### PR DESCRIPTION



## 🤖 New release

* `metarepo-core`: 0.52.0 -> 0.53.2
* `metarepo`: 0.52.0 -> 0.53.2
* `metarepo-plugin-sdk`: 0.52.0 -> 0.53.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `metarepo-core`

<blockquote>

## [0.53.2](https://github.com/codyaverett/metarepo/compare/metarepo-core-v0.52.0...metarepo-core-v0.53.2) - 2026-06-12

### Added

- *(skill)* steal and add skills from a specific git branch, tag, or commit (v0.53.0)

### Other

- *(deps)* bump toml from 0.8.23 to 1.1.2+spec-1.1.0
- *(security)* add supply-chain threat model document (v0.53.2)
- *(backlog)* add 2026-06-12 backlog grooming record (v0.53.1)
</blockquote>

## `metarepo`

<blockquote>

## [0.53.2](https://github.com/codyaverett/metarepo/compare/v0.52.0...v0.53.2) - 2026-06-12

### Added

- *(skill)* steal and add skills from a specific git branch, tag, or commit (v0.53.0)

### Other

- *(deps)* bump git2 from 0.18.3 to 0.21.0
- *(deps)* bump sha2 from 0.10.9 to 0.11.0
- *(deps)* bump toml from 0.8.23 to 1.1.2+spec-1.1.0
- *(deps)* bump colored from 2.2.0 to 3.1.1
- *(security)* add supply-chain threat model document (v0.53.2)
- *(backlog)* add 2026-06-12 backlog grooming record (v0.53.1)
</blockquote>

## `metarepo-plugin-sdk`

<blockquote>

## [0.53.0](https://github.com/codyaverett/metarepo/compare/metarepo-plugin-sdk-v0.52.0...metarepo-plugin-sdk-v0.53.0) - 2026-06-12

### Added

- *(skill)* steal and add skills from a specific git branch, tag, or commit (v0.53.0)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).